### PR TITLE
Fix square tool previews

### DIFF
--- a/src/ssm/DrawPanel.java
+++ b/src/ssm/DrawPanel.java
@@ -117,7 +117,7 @@ public class DrawPanel extends JPanel implements MouseInputListener, ColourObjec
             currentTool.use(currentPixelX, currentPixelY, primary, drawBuffer, writeBuffer, scale);
         if(SwingUtilities.isRightMouseButton(e))
         currentTool.use(currentPixelX, currentPixelY, secondary, drawBuffer, writeBuffer, scale);
-        currentTool.preview(currentPixelX, currentPixelY, overlayBuffer, scale);
+        currentTool.preview(currentPixelX, currentPixelY, drawBuffer, overlayBuffer, scale);
     }
 
     public void mouseMoved(MouseEvent e) {
@@ -127,7 +127,7 @@ public class DrawPanel extends JPanel implements MouseInputListener, ColourObjec
         if (eventX != currentPixelX || eventY != currentPixelY) {
             currentPixelX = eventX;
             currentPixelY = eventY;
-            currentTool.preview(currentPixelX, currentPixelY, overlayBuffer, scale);
+            currentTool.preview(currentPixelX, currentPixelY, drawBuffer, overlayBuffer, scale);
         }
     }
 
@@ -148,7 +148,7 @@ public class DrawPanel extends JPanel implements MouseInputListener, ColourObjec
         int onMask = 0;
         int offMask = MouseEvent.BUTTON1_DOWN_MASK | MouseEvent.BUTTON2_DOWN_MASK | MouseEvent.BUTTON3_DOWN_MASK;
         if ((e.getModifiersEx() & (onMask | offMask)) == onMask)
-            currentTool.preview(currentPixelX, currentPixelY, overlayBuffer, scale);
+            currentTool.preview(currentPixelX, currentPixelY, drawBuffer, overlayBuffer, scale);
     }
 
     public void mousePressed(MouseEvent e) {}

--- a/src/ssm/colour/ColourOp.java
+++ b/src/ssm/colour/ColourOp.java
@@ -1,0 +1,48 @@
+package ssm.colour;
+
+public class ColourOp {
+    public static int sum(int a, int b) {
+        int aA = a >> 24 & 255;
+        int aR = a >> 16 & 255;
+        int aG = a >> 8 & 255;
+        int aB = a & 255;
+
+        int bA = b >> 24 & 255;
+        int bR = b >> 16 & 255;
+        int bG = b >> 8 & 255;
+        int bB = b & 255;
+
+        int result = (aB + bB) | (aG + bG) << 8 | (aR + bR) << 16 | (aA + bA) << 24;
+        return result;
+    }
+
+    public static int minus(int a, int b) {
+        int aA = a >> 24 & 255;
+        int aR = a >> 16 & 255;
+        int aG = a >> 8 & 255;
+        int aB = a & 255;
+
+        int bA = b >> 24 & 255;
+        int bR = b >> 16 & 255;
+        int bG = b >> 8 & 255;
+        int bB = b & 255;
+
+        int result = (aB - bB) | (aG - bG) << 8 | (aR - bR) << 16 | (aA - bA) << 24;
+        return result;
+    }
+
+    public static int divide(int a, int b) {
+        int aA = a >> 24 & 255;
+        int aR = a >> 16 & 255;
+        int aG = a >> 8 & 255;
+        int aB = a & 255;
+
+        int bA = b >> 24 & 255;
+        int bR = b >> 16 & 255;
+        int bG = b >> 8 & 255;
+        int bB = b & 255;
+
+        int result = (aB / bB) | (aG / bG) << 8 | (aR / bR) << 16 | (aA / bA) << 24;
+        return result;
+    }
+}

--- a/src/ssm/tools/FillTool.java
+++ b/src/ssm/tools/FillTool.java
@@ -36,7 +36,7 @@ public class FillTool extends Tool {
         fill(x, y - 1, c, buffer, scale, startColor);
         fill(x, y + 1, c, buffer, scale, startColor);
     }
-    public void preview(int x, int y, BufferedImage overlayBuffer, int scale) {
+    public void preview(int x, int y, BufferedImage drawBuffer, BufferedImage overlayBuffer, int scale) {
 
     }
 

--- a/src/ssm/tools/SquareBrush.java
+++ b/src/ssm/tools/SquareBrush.java
@@ -4,22 +4,12 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
-public class SquareBrush extends DrawTool {
+public class SquareBrush extends SquareTool {
     protected void draw(int x, int y, Color c, BufferedImage buffer, int scale) {
         Graphics2D b2 = (Graphics2D) buffer.getGraphics();
         b2.setColor(c);
         b2.scale(scale, scale);
         b2.fillRect(x, y, size, size);
         b2.dispose();
-    }
-
-    public void preview(int x, int y, BufferedImage overlayBuffer, int scale) {
-        clearPreview(overlayBuffer);
-        int screenX = x * scale;
-        int screenY = y * scale;
-        Graphics2D o2 = (Graphics2D) overlayBuffer.getGraphics();
-        o2.setColor(Color.BLACK);
-        o2.drawRect(screenX, screenY, size * scale - 1, size * scale - 1);
-        o2.dispose();
     }
 }

--- a/src/ssm/tools/SquareEraser.java
+++ b/src/ssm/tools/SquareEraser.java
@@ -1,10 +1,9 @@
 package ssm.tools;
 
 import java.awt.Color;
-import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 
-public class SquareEraser extends DrawTool {
+public class SquareEraser extends SquareTool {
     public void draw(int x, int y, Color c, BufferedImage buffer, int scale) {
         int screenX = x * scale;
         int screenY = y * scale;
@@ -14,15 +13,5 @@ public class SquareEraser extends DrawTool {
                     buffer.setRGB(i, j, 0);
             }
         }
-    }
-
-    public void preview(int x, int y, BufferedImage overlayBuffer, int scale) {
-        clearPreview(overlayBuffer);
-        int screenX = x * scale;
-        int screenY = y * scale;
-        Graphics2D o2 = (Graphics2D) overlayBuffer.getGraphics();
-        o2.setColor(Color.BLACK);
-        o2.drawRect(screenX, screenY, size * scale - 1, size * scale - 1);
-        o2.dispose();
     }
 }

--- a/src/ssm/tools/SquareTool.java
+++ b/src/ssm/tools/SquareTool.java
@@ -1,0 +1,36 @@
+package ssm.tools;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+import ssm.colour.ColourOp;
+
+public abstract class SquareTool extends DrawTool {
+    public void preview(int x, int y, BufferedImage drawBuffer, BufferedImage overlayBuffer, int scale) {
+        clearPreview(overlayBuffer);
+        int screenX = x * scale;
+        int screenY = y * scale;
+        int screenEast = overlayBuffer.getWidth() - 1;
+        int screenSouth = overlayBuffer.getHeight() - 1;
+
+        int pixelEast = screenX + size * scale - 1;
+        int pixelSouth = screenY + size * scale - 1;
+
+        for (int i = screenX; i <= pixelEast; i++) {
+            for (int j = screenY; j <= pixelSouth; j++) {
+                if (i > screenEast || j > screenSouth || i < 0 || j < 0)
+                    continue;
+                int bRGB = drawBuffer.getRGB(i, j);
+                int result = ColourOp.minus(Color.BLACK.getRGB(), bRGB);
+                if (bRGB == Color.BLACK.getRGB())
+                    result = Color.WHITE.getRGB();
+                if (i == screenX || i == pixelEast){   
+                    overlayBuffer.setRGB(i, j, result);
+                }
+                if (j == screenY || j == pixelSouth) {
+                    overlayBuffer.setRGB(i, j, result);
+                }
+            }
+        }
+    }
+}

--- a/src/ssm/tools/Tool.java
+++ b/src/ssm/tools/Tool.java
@@ -11,7 +11,7 @@ public abstract class Tool {
         draw(x, y, c, drawBuffer, scale);
         draw(x, y, c, writeBuffer, 1);
     }
-    public abstract void preview(int x, int y, BufferedImage overlayBuffer, int scale);
+    public abstract void preview(int x, int y, BufferedImage drawBuffer, BufferedImage overlayBuffer, int scale);
     protected void clearPreview(BufferedImage overlayBuffer) {
         int width = overlayBuffer.getWidth();
         int height = overlayBuffer.getHeight();


### PR DESCRIPTION
Square tool previews are now dynamically coloursed. The colour is determined by a simple subtraction implemented in the new ColourOp class. This makes it more visible over every colour.