### PR TITLE
Fix fill looping

### DIFF
--- a/src/ssm/tools/FillTool.java
+++ b/src/ssm/tools/FillTool.java
@@ -11,7 +11,6 @@ public class FillTool extends Tool {
         int screenX = x * scale;
         int screenY = y * scale;
         int startColor = buffer.getRGB(screenX, screenY);
-        
 
         fill(x, y, c, buffer, scale, startColor);
     }
@@ -19,23 +18,31 @@ public class FillTool extends Tool {
     private void fill(int x, int y, Color c, BufferedImage buffer, int scale, int startColor) {
         int screenX = x * scale;
         int screenY = y * scale;
-
+        
         if (x < 0 || screenX > buffer.getWidth() - 1 || y < 0 || screenY > buffer.getHeight() - 1)
             return;
 
-        if (buffer.getRGB(screenX, screenY) != startColor || buffer.getRGB(screenX, screenY) == c.getRGB())
-            return;
+        int currentRGB = buffer.getRGB(screenX, screenY);
         
+        if (currentRGB != startColor || currentRGB == c.getRGB())
+            return;
+
         Graphics2D b2 = (Graphics2D) buffer.getGraphics();
         b2.scale(scale, scale);
         b2.setColor(c);
         b2.fillRect(x, y, 1, 1);
         b2.dispose();
+
+        if (buffer.getRGB(screenX, screenY) == currentRGB)
+            return;
+
         fill(x - 1, y, c, buffer, scale, startColor);
         fill(x + 1, y, c, buffer, scale, startColor);
         fill(x, y - 1, c, buffer, scale, startColor);
         fill(x, y + 1, c, buffer, scale, startColor);
+
     }
+
     public void preview(int x, int y, BufferedImage overlayBuffer, int scale) {
 
     }


### PR DESCRIPTION
Introducing alpha values made it impossible to determine when to stop the fill. Previously, if the colour being filled was the same as the colour already on the buffer, the fill would terminate. However, if the colour on the buffer was fully opaque, its integer value would be different from a colour with the same RGB value but different a different alpha. This would result in no physical change to the buffer, but the colour being filled would still be different from the colour in the buffer, preventing termination. This fix checks the colour in the buffer after the fill to see if it changed - if not, it terminates.