### PR TITLE
Fix drawpanel rendering

### DIFF
--- a/src/ssm/MainWindow.java
+++ b/src/ssm/MainWindow.java
@@ -3,6 +3,8 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.util.ArrayList;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -45,6 +47,11 @@ public class MainWindow extends JFrame implements Runnable {
         refreshThread = new Thread(this);
         refreshThread.start();
         drawPanel.postGraphicsInit();
+        addComponentListener(new ComponentAdapter() {
+            public void componentResized(ComponentEvent e) {
+                drawPanel.render();
+            }
+        });
     }
 
     private void initComponents() {

--- a/src/ssm/MainWindow.java
+++ b/src/ssm/MainWindow.java
@@ -42,11 +42,9 @@ public class MainWindow extends JFrame implements Runnable {
         setVisible(true);
         setBackground(new Color(240, 240, 240));
         colourManager.updateColourObjects();
-        drawPanel.clear();
-        drawPanel.requestFocus();
         refreshThread = new Thread(this);
         refreshThread.start();
-        drawPanel.render();
+        drawPanel.postGraphicsInit();
     }
 
     private void initComponents() {

--- a/src/ssm/MainWindow.java
+++ b/src/ssm/MainWindow.java
@@ -5,6 +5,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -49,6 +51,11 @@ public class MainWindow extends JFrame implements Runnable {
         drawPanel.postGraphicsInit();
         addComponentListener(new ComponentAdapter() {
             public void componentResized(ComponentEvent e) {
+                drawPanel.render();
+            }
+        });
+        addWindowListener(new WindowAdapter() {
+            public void windowActivated(WindowEvent e) {
                 drawPanel.render();
             }
         });

--- a/src/ssm/draw/DrawPanel.java
+++ b/src/ssm/draw/DrawPanel.java
@@ -30,7 +30,6 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
     private int currentPixelX, currentPixelY;
     private int resizeX, resizeY, resizeFactor;
     private int panelWidth, panelHeight;
-    private int mouseX, mouseY;
     private DrawingMouseListener drawingMouseListener;
     
     public DrawPanel() {
@@ -63,9 +62,9 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
         currentPixelX = currentPixelY = -1;
         drawBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         overlayBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-        renderBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        renderBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         writeBuffer = new BufferedImage(width / scale, height / scale, BufferedImage.TYPE_INT_ARGB);
-        backgroundBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        backgroundBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         compositeBuffer = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
         imageFileManager.setToWrite(writeBuffer);
         toolManager.getSquareBrush();
@@ -85,7 +84,7 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
         c2.dispose();
         Graphics2D g2 = (Graphics2D) getGraphics();
         if (g2 == null)
-            return;
+            return;        
         g2.drawImage(compositeBuffer, 0, 0, null);
         g2.dispose();
     }
@@ -168,13 +167,12 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
     private void reposition(float percentX, float percentY) {
         this.percentX = percentX;
         this.percentY = percentY;
+        positionDrawing();
     }
 
-    private void reposition(int mouseX, int mouseY) {
-        
-        float diffX = mouseX - this.mouseX;
-        float diffY = mouseY - this.mouseY;
-        
+    public void reposition(int newX, int newY, int oldX, int oldY) {  
+        float diffX = newX - oldX;
+        float diffY = newY - oldY;
         percentX += diffX / panelWidth;
         percentY += diffY / panelHeight;
         reposition(percentX, percentY);
@@ -191,7 +189,7 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
 
     private void resetBackground() {
         if (getHeight() > 0 && getWidth() > 0)
-            backgroundBuffer = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+            backgroundBuffer = new BufferedImage(getWidth(), getHeight(), BufferedImage.TYPE_INT_RGB);
         clearBuffer(backgroundBuffer);
         Graphics2D b2 = (Graphics2D) backgroundBuffer.getGraphics();
         b2.setBackground(getBackground());

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -22,12 +22,14 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
             drawPanel.useTool(0);
         if(SwingUtilities.isRightMouseButton(e))
             drawPanel.useTool(1);
+        drawPanel.render();
     }
 
     @Override
     public void mousePressed(MouseEvent e) {
         mouseX = e.getX();
         mouseY = e.getY();
+        drawPanel.render();
     }
 
     @Override
@@ -39,11 +41,13 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
         int offMask = MouseEvent.BUTTON1_DOWN_MASK | MouseEvent.BUTTON2_DOWN_MASK | MouseEvent.BUTTON3_DOWN_MASK;
         if ((e.getModifiersEx() & (onMask | offMask)) == onMask)
             drawPanel.previewTool();
+        drawPanel.render();
     }
 
     @Override
     public void mouseExited(MouseEvent e) {
         drawPanel.clearOverlay();
+        drawPanel.render();
     }
 
     @Override
@@ -54,6 +58,7 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
         if(SwingUtilities.isRightMouseButton(e))
             drawPanel.useTool(1);
         drawPanel.previewTool();
+        drawPanel.render();
     }
 
     @Override
@@ -62,12 +67,14 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
         mouseY = e.getY();
         drawPanel.scaleInput(mouseX, mouseY);
         drawPanel.previewTool();
+        drawPanel.render();
     }
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
         int resizeAmount = e.getWheelRotation();
         drawPanel.resize(resizeAmount);
+        drawPanel.render();
     }
     
 }

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -52,6 +52,13 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
 
     @Override
     public void mouseDragged(MouseEvent e) {
+        if (SwingUtilities.isMiddleMouseButton(e)) {
+            int eventX = e.getX();
+            int eventY = e.getY();
+            drawPanel.reposition(eventX, eventY, mouseX, mouseY);
+            mouseX = eventX;
+            mouseY = eventY;
+        }
         drawPanel.scaleInput(e.getX(), e.getY());
         if(SwingUtilities.isLeftMouseButton(e))
             drawPanel.useTool(0);
@@ -72,6 +79,9 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e) {
+        if (SwingUtilities.isMiddleMouseButton(e)) {
+            return;
+        }
         int resizeAmount = e.getWheelRotation();
         drawPanel.resize(resizeAmount);
         drawPanel.render();


### PR DESCRIPTION
DrawPanel no longer renders on the thread because drawing is expensive. Instead, it is rendered whenever an event that should change the panel is triggered (mouse movement, clicks, drags). This led to some graphical glitches when the window is resized - the render would happen, but then get erased (presumably due to some lower conflict in the order of operations). The current fix is to rerender whenever the window or the panel gets resized using the Window and Component listeners. This may lead to a few wasteful renders at times, but it is certainly better that rendering on the thread. The panel also gets rendered whenever the window is activated, which allows it to display properly if the window was minimized.