### PR TITLE
Update event handling

### DIFF
--- a/src/ssm/draw/DrawPanel.java
+++ b/src/ssm/draw/DrawPanel.java
@@ -144,7 +144,8 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
         resetBackground();
     }
 
-    public void useTool(int option) {
+    public void useTool(int eventX, int eventY, int option) {
+        scaleInput(eventX, eventY);
         if (option == 0) {
             currentTool.use(currentPixelX, currentPixelY, primary, drawBuffer, writeBuffer, scale);
         }
@@ -157,6 +158,13 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
         currentTool.preview(currentPixelX, currentPixelY, drawBuffer, overlayBuffer, scale);
     }
 
+    public boolean comparePixel(int eventX, int eventY) {
+        int newX = ((eventX - x) / scale) / (resizeX / scaleWidth);
+        int newY = ((eventY - y) / scale) / (resizeY / scaleHeight);
+        if (newX == currentPixelX && newY == currentPixelY)
+            return true;
+        return false;
+    }
     public void scaleInput(int eventX, int eventY) {
         currentPixelX = ((eventX - x) / scale) / (resizeX / scaleWidth);
         currentPixelY = ((eventY - y) / scale) / (resizeY / scaleHeight);

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -18,22 +18,29 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
 
     @Override
     public void mouseClicked(MouseEvent e) {
-        if(SwingUtilities.isLeftMouseButton(e))
-            drawPanel.useTool(0);
-        if(SwingUtilities.isRightMouseButton(e))
-            drawPanel.useTool(1);
+        int eventX = e.getX();
+        int eventY = e.getY();
+        if (SwingUtilities.isLeftMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 0);
+        if (SwingUtilities.isRightMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 1);
         drawPanel.render();
     }
 
     @Override
     public void mousePressed(MouseEvent e) {
-        mouseX = e.getX();
-        mouseY = e.getY();
+        int eventX = mouseX = e.getX();
+        int eventY = mouseY = e.getY();
+        if (SwingUtilities.isLeftMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 0);
+        if (SwingUtilities.isRightMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 1);
         drawPanel.render();
     }
 
     @Override
-    public void mouseReleased(MouseEvent e) {}
+    public void mouseReleased(MouseEvent e) {
+    }
 
     @Override
     public void mouseEntered(MouseEvent e) {
@@ -52,18 +59,19 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
 
     @Override
     public void mouseDragged(MouseEvent e) {
+        int eventX = e.getX();
+        int eventY = e.getY();
+        if (drawPanel.comparePixel(eventX, eventY))
+            return;
         if (SwingUtilities.isMiddleMouseButton(e)) {
-            int eventX = e.getX();
-            int eventY = e.getY();
             drawPanel.reposition(eventX, eventY, mouseX, mouseY);
             mouseX = eventX;
             mouseY = eventY;
         }
-        drawPanel.scaleInput(e.getX(), e.getY());
-        if(SwingUtilities.isLeftMouseButton(e))
-            drawPanel.useTool(0);
-        if(SwingUtilities.isRightMouseButton(e))
-            drawPanel.useTool(1);
+        if (SwingUtilities.isLeftMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 0);
+        if (SwingUtilities.isRightMouseButton(e))
+            drawPanel.useTool(eventX, eventY, 1);
         drawPanel.previewTool();
         drawPanel.render();
     }
@@ -86,5 +94,5 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
         drawPanel.resize(resizeAmount);
         drawPanel.render();
     }
-    
+
 }

--- a/src/ssm/tools/FillTool.java
+++ b/src/ssm/tools/FillTool.java
@@ -24,7 +24,7 @@ public class FillTool extends Tool {
 
         int currentRGB = buffer.getRGB(screenX, screenY);
         
-        if (currentRGB != startColor || currentRGB == c.getRGB())
+        if (currentRGB != startColor)
             return;
 
         Graphics2D b2 = (Graphics2D) buffer.getGraphics();


### PR DESCRIPTION
Fixes #14 by adding a check to the event handling. While dragging, drag events within the same pixel no longer trigger repeated uses of the tool, so the transparency remains consistent. It's not ideal, however, since revisiting pixels while the button is still held down will retrigger the draw.