### PR TITLE
Rework mouse event handling

### DIFF
--- a/src/ssm/draw/DrawPanel.java
+++ b/src/ssm/draw/DrawPanel.java
@@ -253,6 +253,10 @@ public class DrawPanel extends JPanel implements ColourObject, Refreshable, Tool
         currentTool = tool;
     }
 
+    public Tool getCurrentTool() {
+        return currentTool;
+    }
+
     public int getPixelWidth() {
         return WIDTH;
     }

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -17,15 +17,7 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
     }
 
     @Override
-    public void mouseClicked(MouseEvent e) {
-        int eventX = e.getX();
-        int eventY = e.getY();
-        if (SwingUtilities.isLeftMouseButton(e))
-            drawPanel.useTool(eventX, eventY, 0);
-        if (SwingUtilities.isRightMouseButton(e))
-            drawPanel.useTool(eventX, eventY, 1);
-        drawPanel.render();
-    }
+    public void mouseClicked(MouseEvent e) {}
 
     @Override
     public void mousePressed(MouseEvent e) {

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -3,9 +3,9 @@ package ssm.draw;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
-
 import javax.swing.SwingUtilities;
 import javax.swing.event.MouseInputListener;
+import ssm.tools.ToolManager.ToolType;
 
 public class DrawingMouseListener implements MouseInputListener, MouseWheelListener {
     private DrawPanel drawPanel;
@@ -61,6 +61,8 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
             mouseX = eventX;
             mouseY = eventY;
         }
+        if (drawPanel.getCurrentTool().getToolType() == ToolType.FILLTOOL)
+            return;
         if (SwingUtilities.isLeftMouseButton(e))
             drawPanel.useTool(eventX, eventY, 0);
         if (SwingUtilities.isRightMouseButton(e))

--- a/src/ssm/draw/DrawingMouseListener.java
+++ b/src/ssm/draw/DrawingMouseListener.java
@@ -60,6 +60,8 @@ public class DrawingMouseListener implements MouseInputListener, MouseWheelListe
             drawPanel.reposition(eventX, eventY, mouseX, mouseY);
             mouseX = eventX;
             mouseY = eventY;
+            drawPanel.render();
+            return;
         }
         if (drawPanel.getCurrentTool().getToolType() == ToolType.FILLTOOL)
             return;

--- a/src/ssm/tools/FillTool.java
+++ b/src/ssm/tools/FillTool.java
@@ -10,6 +10,10 @@ public class FillTool extends Tool {
     public void draw(int x, int y, Color c, BufferedImage buffer, int scale) {
         int screenX = x * scale;
         int screenY = y * scale;
+
+        if (x < 0 || screenX > buffer.getWidth() - 1 || y < 0 || screenY > buffer.getHeight() - 1)
+            return;
+            
         int startColor = buffer.getRGB(screenX, screenY);
 
         fill(x, y, c, buffer, scale, startColor);


### PR DESCRIPTION
Fixed #23. Fill tool no longer redraws on mouse drag, but the solution is messy. The event listener class has to ask if the fill tool is selected and then decide to ignore the mouse drag event. Cannot solve translucency issues on brushes (particularly brushes bigger than size 1) without having the brush itself be coupled to the event listener (so it knows if the mouse has been released), which defeats the current Tool abstraction. That would require a reworking of Tools, which isn't a high priority right now.